### PR TITLE
Add requirements.txt for pip dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+openai
+PyMuPDF
+watchdog


### PR DESCRIPTION
## Summary
- document Python dependencies in `requirements.txt`

## Testing
- `pip install -r requirements.txt` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_683f708d2e5883209cffb45f2f36373a