### PR TITLE
Fix file processing and add Streamlit UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,10 +36,10 @@ OPENAI_MODEL='gpt-4.1-nano'
 Starten Sie die Anwendung mit:
 
 ```bash
-python pdf_renamer.py
+streamlit run streamlit_app.py
 ```
 
-Das Skript überwacht anschließend das Eingangsverzeichnis und benennt neue PDFs selbstständig um.
+Die Anwendung überwacht das Eingangsverzeichnis und benennt sowohl bereits vorhandene als auch neue PDFs automatisch um. Eine kleine Weboberfläche zeigt den aktuellen Status an.
 
 ### Dauerbetrieb
 Für einen permanenten Einsatz lässt sich das Skript z. B. als systemd- oder Windows-Dienst starten oder in den Autostart legen.

--- a/pdf_renamer.py
+++ b/pdf_renamer.py
@@ -33,11 +33,22 @@ def convert_pdf_to_images(pdf_path: str) -> list[str]:
 
 
 class FileHandler(FileSystemEventHandler):
-    def __init__(self, input_dir: str, output_dir: str) -> None:
+    def __init__(self, input_dir: str, output_dir: str, on_processed=None) -> None:
         self.input_dir = input_dir
         self.output_dir = output_dir
-        os.makedirs(output_dir, exist_ok=True)
+        self.on_processed = on_processed
+        os.makedirs(self.output_dir, exist_ok=True)
+        os.makedirs(self.input_dir, exist_ok=True)
         self.executor = ThreadPoolExecutor(max_workers=4)
+        self.process_existing_pdfs()
+
+    def process_existing_pdfs(self) -> None:
+        """Verarbeitet bereits vorhandene PDFs im Eingangsverzeichnis."""
+        for file_name in os.listdir(self.input_dir):
+            if file_name.lower().endswith(".pdf"):
+                path = os.path.join(self.input_dir, file_name)
+                logging.info(f"Verarbeite vorhandene Datei: {path}")
+                self.executor.submit(self.process_pdf, path)
 
     def on_created(self, event) -> None:
         if event.is_directory:
@@ -60,6 +71,8 @@ class FileHandler(FileSystemEventHandler):
                 counter += 1
             shutil.move(pdf_path, new_path)
             logging.info(f"Datei verschoben nach {new_path}")
+            if self.on_processed:
+                self.on_processed(new_path)
         except Exception as e:
             logging.error(f"Fehler beim Verarbeiten von {pdf_path}: {e}")
             fallback_name = f"Fehler_doc_{os.path.basename(pdf_path)}"
@@ -67,6 +80,8 @@ class FileHandler(FileSystemEventHandler):
             try:
                 shutil.move(pdf_path, fallback_path)
                 logging.info(f"Fallback-Name verwendet: {fallback_path}")
+                if self.on_processed:
+                    self.on_processed(fallback_path)
             except Exception as e2:
                 logging.critical(
                     f"Kritischer Fehler: Datei {pdf_path} konnte nicht verschoben werden - {e2}")

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ openai
 PyMuPDF
 watchdog
 python-dotenv
+streamlit
+pytest

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,0 +1,51 @@
+import os
+import threading
+import streamlit as st
+from watchdog.observers import Observer
+from pdf_renamer import FileHandler
+
+st.title("PDF Auto Renamer")
+input_dir = st.text_input("Eingangsverzeichnis", os.getenv("INPUT_DIR", "C:/tmp/PDF_Input"))
+output_dir = st.text_input("Ausgabeverzeichnis", os.getenv("OUTPUT_DIR", "C:/tmp/PDF_Processed"))
+
+if 'processed_files' not in st.session_state:
+    st.session_state.processed_files = []
+
+observer = st.session_state.get('observer')
+handler = st.session_state.get('handler')
+
+
+def on_processed(path: str) -> None:
+    st.session_state.processed_files.append(os.path.basename(path))
+
+
+def start_watching() -> None:
+    handler = FileHandler(input_dir, output_dir, on_processed=on_processed)
+    observer = Observer()
+    observer.schedule(handler, input_dir, recursive=False)
+    observer.start()
+    st.session_state.observer = observer
+    st.session_state.handler = handler
+
+
+def stop_watching() -> None:
+    observer = st.session_state.get('observer')
+    handler = st.session_state.get('handler')
+    if observer and handler:
+        observer.stop()
+        observer.join()
+        handler.executor.shutdown(wait=True)
+    st.session_state.observer = None
+    st.session_state.handler = None
+
+col1, col2 = st.columns(2)
+if col1.button("Überwachung starten") and observer is None:
+    threading.Thread(target=start_watching, daemon=True).start()
+    st.success("Überwachung gestartet")
+if col2.button("Überwachung stoppen") and observer:
+    stop_watching()
+    st.warning("Überwachung gestoppt")
+
+st.subheader("Verarbeitete Dateien")
+for f in st.session_state.processed_files[-20:]:
+    st.write(f)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -1,0 +1,28 @@
+import os
+from pathlib import Path
+from unittest import mock
+import fitz
+
+from pdf_renamer import FileHandler
+
+
+def create_dummy_pdf(path: Path) -> None:
+    doc = fitz.open()
+    doc.new_page()
+    doc.save(str(path))
+    doc.close()
+
+
+def test_process_existing_pdfs(tmp_path):
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    input_dir.mkdir()
+    output_dir.mkdir()
+    pdf_path = input_dir / "sample.pdf"
+    create_dummy_pdf(pdf_path)
+
+    with mock.patch.object(FileHandler, "generate_filename_with_openai", return_value="test_doc"):
+        handler = FileHandler(str(input_dir), str(output_dir))
+        handler.executor.shutdown(wait=True)
+
+    assert (output_dir / "test_doc.pdf").exists()


### PR DESCRIPTION
## Summary
- create Streamlit interface to monitor and control the renamer
- ensure input directory exists and process existing PDFs on startup
- add callback support to notify UI about processed files
- document new streamlit launch command in the README
- add tests for processing existing files

## Testing
- `python -m py_compile pdf_renamer.py streamlit_app.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_685d6d362b2c83209324e051054cb8f8