### PR TITLE
Fix PDF processing race condition

### DIFF
--- a/pdf_renamer.py
+++ b/pdf_renamer.py
@@ -17,8 +17,26 @@ from openai import OpenAI
 load_dotenv()
 openai_client = OpenAI(api_key=os.getenv("OPENAI_API_KEY"))
 MODEL_NAME = os.getenv("OPENAI_MODEL", "gpt-4.1-nano")
-logging.basicConfig(level=logging.INFO,
-                    format='%(asctime)s - %(levelname)s - %(message)s')
+logging.basicConfig(
+    level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
+)
+
+
+def wait_for_file_ready(
+    path: str, timeout: float = 10.0, interval: float = 0.5
+) -> bool:
+    """Wait until a file is ready for reading."""
+    start = time.time()
+    while time.time() - start < timeout:
+        if os.path.exists(path):
+            try:
+                with open(path, "rb"):
+                    return True
+            except Exception:
+                time.sleep(interval)
+        else:
+            time.sleep(interval)
+    return False
 
 
 def convert_pdf_to_images(pdf_path: str) -> list[str]:
@@ -53,12 +71,14 @@ class FileHandler(FileSystemEventHandler):
     def on_created(self, event) -> None:
         if event.is_directory:
             return
-        if event.src_path.lower().endswith('.pdf'):
+        if event.src_path.lower().endswith(".pdf"):
             logging.info(f"Neue PDF erkannt: {event.src_path}")
             self.executor.submit(self.process_pdf, event.src_path)
 
     def process_pdf(self, pdf_path: str) -> None:
         try:
+            if not wait_for_file_ready(pdf_path):
+                raise FileNotFoundError(f"File {pdf_path} is not ready for processing.")
             images = convert_pdf_to_images(pdf_path)
             filename = self.generate_filename_with_openai(images)
             new_name = f"{filename}.pdf"
@@ -84,7 +104,8 @@ class FileHandler(FileSystemEventHandler):
                     self.on_processed(fallback_path)
             except Exception as e2:
                 logging.critical(
-                    f"Kritischer Fehler: Datei {pdf_path} konnte nicht verschoben werden - {e2}")
+                    f"Kritischer Fehler: Datei {pdf_path} konnte nicht verschoben werden - {e2}"
+                )
 
     def generate_filename_with_openai(self, images: list[str]) -> str:
         prompt = (

--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -1,22 +1,37 @@
 import os
 import threading
+import queue
 import streamlit as st
 from watchdog.observers import Observer
 from pdf_renamer import FileHandler
 
 st.title("PDF Auto Renamer")
-input_dir = st.text_input("Eingangsverzeichnis", os.getenv("INPUT_DIR", "C:/tmp/PDF_Input"))
-output_dir = st.text_input("Ausgabeverzeichnis", os.getenv("OUTPUT_DIR", "C:/tmp/PDF_Processed"))
+input_dir = st.text_input(
+    "Eingangsverzeichnis", os.getenv("INPUT_DIR", "C:/tmp/PDF_Input")
+)
+output_dir = st.text_input(
+    "Ausgabeverzeichnis", os.getenv("OUTPUT_DIR", "C:/tmp/PDF_Processed")
+)
 
-if 'processed_files' not in st.session_state:
+processed_queue: "queue.Queue[str]" = (
+    st.session_state.get("processed_queue") or queue.Queue()
+)
+st.session_state.processed_queue = processed_queue
+
+if "processed_files" not in st.session_state:
     st.session_state.processed_files = []
 
-observer = st.session_state.get('observer')
-handler = st.session_state.get('handler')
+observer = st.session_state.get("observer")
+handler = st.session_state.get("handler")
 
 
 def on_processed(path: str) -> None:
-    st.session_state.processed_files.append(os.path.basename(path))
+    st.session_state.processed_queue.put(os.path.basename(path))
+
+
+def sync_processed_files() -> None:
+    while not st.session_state.processed_queue.empty():
+        st.session_state.processed_files.append(st.session_state.processed_queue.get())
 
 
 def start_watching() -> None:
@@ -29,14 +44,15 @@ def start_watching() -> None:
 
 
 def stop_watching() -> None:
-    observer = st.session_state.get('observer')
-    handler = st.session_state.get('handler')
+    observer = st.session_state.get("observer")
+    handler = st.session_state.get("handler")
     if observer and handler:
         observer.stop()
         observer.join()
         handler.executor.shutdown(wait=True)
     st.session_state.observer = None
     st.session_state.handler = None
+
 
 col1, col2 = st.columns(2)
 if col1.button("Überwachung starten") and observer is None:
@@ -45,6 +61,8 @@ if col1.button("Überwachung starten") and observer is None:
 if col2.button("Überwachung stoppen") and observer:
     stop_watching()
     st.warning("Überwachung gestoppt")
+
+sync_processed_files()
 
 st.subheader("Verarbeitete Dateien")
 for f in st.session_state.processed_files[-20:]:

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -21,7 +21,9 @@ def test_process_existing_pdfs(tmp_path):
     pdf_path = input_dir / "sample.pdf"
     create_dummy_pdf(pdf_path)
 
-    with mock.patch.object(FileHandler, "generate_filename_with_openai", return_value="test_doc"):
+    with mock.patch.object(
+        FileHandler, "generate_filename_with_openai", return_value="test_doc"
+    ):
         handler = FileHandler(str(input_dir), str(output_dir))
         handler.executor.shutdown(wait=True)
 


### PR DESCRIPTION
## Summary
- wait for files before processing them
- use a thread-safe queue so the Streamlit app updates correctly

## Testing
- `black --check .`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'fitz')*

------
https://chatgpt.com/codex/tasks/task_e_685d745c1ff88320acbde8f31a4eaee7